### PR TITLE
Add unit test coverage report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <mockito.version>1.10.19</mockito.version>
     <integration.test.enabled>false</integration.test.enabled>
     <jersey.version>1.19</jersey.version>
+    <cobertura.version>2.7</cobertura.version>
   </properties>
 
   <modules>
@@ -224,6 +225,7 @@
   </dependencies>
 
   <build>
+    <sourceDirectory>${basedir}/src/main/scala</sourceDirectory>
     <pluginManagement>
       <plugins>
 
@@ -540,6 +542,20 @@
           </execution>
         </executions>
       </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <version>${cobertura.version}</version>
+          <configuration>
+            <check>
+              <haltOnFailure>false</haltOnFailure>
+              <branchRate>80</branchRate>
+              <lineRate>80</lineRate>
+            </check>
+          </configuration>
+
+        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In order to help with increasing unit test coverage in the future, a code coverage report is needed to assist the developers.

## How was this patch tested?

Cobertura code coverage report plugin has been included in the project.